### PR TITLE
Bump html-proofer from 3.8.0 to 3.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     html-pipeline (2.7.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (3.8.0)
+    html-proofer (3.9.1)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       colorize (~> 0.8)


### PR DESCRIPTION
-

var Minimatch = require("minimatch").Minimatch
var mm = new Minimatch(pattern, options)
